### PR TITLE
Add tvOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     name: "YCoreUI",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v14)
+        .iOS(.v14),
+        .tvOS(.v14)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ _Core components for iOS to accelerate building user interfaces in code._
   This lightweight framework primarily comprises:
   
   * UIView extensions for declarative Auto Layout
-  * UIScrollView extensions to assist with keyboard avoidance
   * UIColor extensions for WCAG 2.0 contrast ratio calculations
-  
+  * (iOS only) UIScrollView extensions to assist with keyboard avoidance
+ 
   It also contains miscellaneous other Foundation and UIKit extensions.
 
 Documentation

--- a/Sources/YCoreUI/Components/FormViewController.swift
+++ b/Sources/YCoreUI/Components/FormViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+#if os(iOS)
 /// A view controller with a scrollable content area that will automatically avoid the keyboard for you.
 /// A good choice for views that have inputs (e.g. login or onboarding).
 open class FormViewController: UIViewController {
@@ -154,3 +155,4 @@ internal extension FormViewController {
         handleTapOutside()
     }
 }
+#endif

--- a/Sources/YCoreUI/Extensions/UIKit/UIScrollView+keyboardNotifications.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIScrollView+keyboardNotifications.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+#if os(iOS)
 extension UIScrollView {
     /// Enables form functionality (content avoids keyboard, sets interactive dismiss mode).
     /// This calls `registerKeyboardNotifications`
@@ -130,3 +131,4 @@ internal extension UIScrollView {
         return UIView.AnimationOptions(rawValue: animationCurve.uintValue << 16)
     }
 }
+#endif

--- a/Tests/YCoreUITests/Components/FormViewControllerTests.swift
+++ b/Tests/YCoreUITests/Components/FormViewControllerTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import YCoreUI
 
+#if os(iOS)
 final class FormViewControllerTests: XCTestCase {
     func testLoadView() {
         let sut = makeSUT()
@@ -151,3 +152,4 @@ final class MockFormViewController: FormViewController {
         didTapOutside = true
     }
 }
+#endif

--- a/Tests/YCoreUITests/Extensions/UIKit/UIScrollView+keyboardNotificationsTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIScrollView+keyboardNotificationsTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import YCoreUI
 
+#if os(iOS)
 final class UIScrollViewKeyboardNotificationsTests: XCTestCase {
     func testShowKeyboard() {
         let sut = makeSUT()
@@ -161,3 +162,4 @@ private extension UIScrollViewKeyboardNotificationsTests {
         RunLoop.current.run(until: Date())
     }
 }
+#endif


### PR DESCRIPTION
## Introduction ##

If we're building tvOS apps with UIKit, we could use YCoreUI to make it simpler.

## Purpose ##

Add tvOS support.

## Scope ##

* Exclude functionality that does not compile for tvOS

## Discussion ##

Was pretty simple. There were two files (and their corresponding unit tests) that needed to be excluded. The remaining unit tests passed without modification.

## 📈 Coverage ##

##### Code: 100% #####

<img width="660" alt="image" src="https://user-images.githubusercontent.com/1037520/192366624-e900717a-5faf-4bca-8fda-29fa384fffd5.png">

##### Documentation: 100% #####

<img width="543" alt="image" src="https://user-images.githubusercontent.com/1037520/192366805-c96f44e8-7031-4ad9-9e1a-a89ed8dff58d.png">
