### PR TITLE
Added extension for UIView constrain center

### DIFF
--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
@@ -1,0 +1,64 @@
+//
+//  UIView+constrainCenter.swift
+//  YCoreUI
+//
+//  Created by Dharmik Ghelani on 20/10/22.
+//  Copyright © 2022 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    /// Struct to define center attribute
+    struct Center: OptionSet {
+        let rawValue: UInt
+        static let x = Center(rawValue: 1 << 0)
+        static let y = Center(rawValue: 1 << 1)
+        static let all: Center = [.x, .y]
+    }
+    
+    /// Constrain the receiving view with provided center attributes
+    /// - Parameters:
+    ///   - center: Center attribute of view to constrain to (default `.all`)
+    ///   - view2: View object to which constrain to (pass `nil` to constrain to superview)
+    ///   - relation: Relation to evaluate (default `.equal`)
+    ///   - offset: Offset to apply to attribute(center X and Y) (default `.zero`)
+    ///   - priority: Constraint priority (default `.required`)
+    ///   - isActive: Whether to activate the constraint or not (default `true`)
+    /// - Returns: The created layout constraint
+    func constrainCenter(
+        _ center: Center = .all,
+        to view2: Anchorable? = nil,
+        relatedBy relation: NSLayoutConstraint.Relation = .equal,
+        offset: UIOffset = .zero,
+        priority: UILayoutPriority = .required,
+        isActive: Bool = true
+    ) -> [NSLayoutConstraint.Attribute: NSLayoutConstraint] {
+        var constraints: [NSLayoutConstraint.Attribute: NSLayoutConstraint] = [:]
+        let otherView: Anchorable! = view2 ?? superview
+        
+        if center.contains(.x) {
+            constraints[.centerX] = constrain(
+                .centerXAnchor,
+                to: otherView.centerXAnchor,
+                relatedBy: relation,
+                constant: offset.horizontal,
+                priority: priority,
+                isActive: isActive
+            )
+        }
+        
+        if center.contains(.y) {
+            constraints[.centerY] = constrain(
+                .centerYAnchor,
+                to: otherView.centerYAnchor,
+                relatedBy: relation,
+                constant: offset.vertical,
+                priority: priority,
+                isActive: isActive
+            )
+        }
+        
+        return constraints
+    }
+}

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
@@ -11,6 +11,7 @@ import UIKit
 extension UIView {
     /// Center alignment options
     public struct Center: OptionSet {
+        /// corresponding raw value
         public let rawValue: UInt
         /// center X
         public static let x = Center(rawValue: 1 << 0)
@@ -18,7 +19,9 @@ extension UIView {
         public static let y = Center(rawValue: 1 << 1)
         /// all (both center X and center Y)
         public static let all: Center = [.x, .y]
-        // initializer must be declared public to matches a (public init) requirement in protocol 'OptionSet'
+        
+        /// Creates the new `Center` option set from the given raw value.
+        /// - Parameter rawValue: the raw value of `Center` option set to create
         public init(rawValue: UInt) {
             self.rawValue = rawValue
         }

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
@@ -13,6 +13,7 @@ extension UIView {
     public struct Center: OptionSet {
         /// corresponding raw value
         public let rawValue: UInt
+        
         /// center X
         public static let x = Center(rawValue: 1 << 0)
         /// center Y

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
@@ -9,24 +9,31 @@
 import UIKit
 
 extension UIView {
-    /// Struct to define center attribute
-    struct Center: OptionSet {
-        let rawValue: UInt
-        static let x = Center(rawValue: 1 << 0)
-        static let y = Center(rawValue: 1 << 1)
-        static let all: Center = [.x, .y]
+    /// Center alignment options
+    public struct Center: OptionSet {
+        public let rawValue: UInt
+        /// center X
+        public static let x = Center(rawValue: 1 << 0)
+        /// center Y
+        public static let y = Center(rawValue: 1 << 1)
+        /// all (both center X and center Y)
+        public static let all: Center = [.x, .y]
+        // initializer must be declared public to matches a (public init) requirement in protocol 'OptionSet'
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
     }
     
-    /// Constrain the receiving view with provided center attributes
+    /// Constrain the center of the receiving view with the center of another view
     /// - Parameters:
-    ///   - center: Center attribute of view to constrain to (default `.all`)
-    ///   - view2: View object to which constrain to (pass `nil` to constrain to superview)
-    ///   - relation: Relation to evaluate (default `.equal`)
-    ///   - offset: Offset to apply to attribute(center X and Y) (default `.zero`)
-    ///   - priority: Constraint priority (default `.required`)
-    ///   - isActive: Whether to activate the constraint or not (default `true`)
-    /// - Returns: The created layout constraint
-    func constrainCenter(
+    ///   - center: which center attributes to constrain (default `.all`)
+    ///   - view2: view or layout guide to constrain to (pass `nil` to constrain to superview)
+    ///   - relation: relation to evaluate (towards view2) (default `.equal`)
+    ///   - offset: offset to apply relative to view2.center (default `.zero`)
+    ///   - priority: constraint priority (default `.required`)
+    ///   - isActive: whether to activate the constraints or not (default `true`)
+    /// - Returns: dictionary of constraints created, keyed by `.centerX, .centerY`
+    public func constrainCenter(
         _ center: Center = .all,
         to view2: Anchorable? = nil,
         relatedBy relation: NSLayoutConstraint.Relation = .equal,

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainCenterTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainCenterTests.swift
@@ -1,0 +1,84 @@
+//
+//  UIView+constrainCenterTests.swift
+//  YCoreUI
+//
+//  Created by Dharmik Ghelani on 20/10/22.
+//  Copyright © 2022 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YCoreUI
+
+final class UIViewConstrainCenterTests: XCTestCase {
+    func testCenterX() {
+        let (sut, offset) = makeSUT()
+        
+        let constraints = sut.view1.constrainCenter(.x, offset: offset)
+        let centerXConstraint = constraints[.centerX]
+        
+        XCTAssertFalse(sut.view1.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertEqual(constraints.count, 1)
+        XCTAssertNotNil(centerXConstraint)
+        XCTAssertEqual(centerXConstraint?.firstItem as? UIView, sut.view1)
+        XCTAssertEqual(centerXConstraint?.firstAttribute, .centerX)
+        XCTAssertEqual(centerXConstraint?.secondItem as? UIView, sut)
+        XCTAssertEqual(centerXConstraint?.secondAttribute, .centerX)
+        XCTAssertEqual(centerXConstraint?.constant, offset.horizontal)
+    }
+    
+    func testCenterY() {
+        let (sut, offset) = makeSUT()
+        
+        let constraints = sut.view1.constrainCenter(.y, offset: offset)
+        let centerYConstraint = constraints[.centerY]
+        
+        XCTAssertFalse(sut.view1.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertEqual(constraints.count, 1)
+        XCTAssertNotNil(centerYConstraint)
+        XCTAssertEqual(centerYConstraint?.firstItem as? UIView, sut.view1)
+        XCTAssertEqual(centerYConstraint?.firstAttribute, .centerY)
+        XCTAssertEqual(centerYConstraint?.secondItem as? UIView, sut)
+        XCTAssertEqual(centerYConstraint?.secondAttribute, .centerY)
+        XCTAssertEqual(centerYConstraint?.constant, offset.vertical)
+    }
+    
+    func testCenterBoth() {
+        let (sut, offset) = makeSUT()
+        
+        let constraints = sut.view1.constrainCenter(offset: offset)
+        
+        let anchorAttributes: [
+            (NSLayoutConstraint.Attribute, CGFloat)
+        ] = [
+            (.centerX, offset.horizontal),
+            (.centerY, offset.vertical)
+        ]
+        
+        XCTAssertFalse(sut.view1.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertEqual(constraints.count, 2)
+        
+        anchorAttributes.forEach {
+            let constraint = constraints[$0.0]
+            XCTAssertNotNil(constraint)
+            XCTAssertEqual(constraint?.firstItem as? UIView, sut.view1)
+            XCTAssertEqual(constraint?.firstAttribute, $0.0)
+            XCTAssertEqual(constraint?.secondItem as? UIView, sut)
+            XCTAssertEqual(constraint?.secondAttribute, $0.0)
+            XCTAssertEqual(constraint?.constant, $0.1)
+        }
+    }
+}
+
+extension UIViewConstrainCenterTests {
+    func makeSUT(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> (MockLayoutContainer, UIOffset) {
+        let container = MockLayoutContainer()
+        let offset = UIOffset(horizontal: 30, vertical: 20)
+        
+        trackForMemoryLeak(container, file: file, line: line)
+        
+        return (container, offset)
+    }
+}


### PR DESCRIPTION
## Introduction ##

Task is to provide easy way to give center constraint to UIView.

## Purpose ##

Added three extra methods in UIView extension to easily deal with center constrain.

## Scope ##

Added new extension file with supporting test case file.

## 📈 Coverage ##

##### Code #####

![Screenshot 2022-10-21 at 1 19 49 PM](https://user-images.githubusercontent.com/115708163/197143706-35f5a49b-09db-4092-b008-cf6da48bb22d.png)

##### Documentation #####

![Screenshot 2022-10-21 at 1 19 20 PM](https://user-images.githubusercontent.com/115708163/197143806-23ce3ee3-257e-4ede-86b2-a0e1186d9c19.png)

##### SwiftLint #####


![Screenshot 2022-10-21 at 1 19 35 PM](https://user-images.githubusercontent.com/115708163/197144032-80ec9c06-dfd6-46ca-8aaa-2c3570bf21ba.png)

