### PR TITLE
Mark constrainCenter return value as discardable

### DIFF
--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainCenter.swift
@@ -37,7 +37,7 @@ extension UIView {
     ///   - priority: constraint priority (default `.required`)
     ///   - isActive: whether to activate the constraints or not (default `true`)
     /// - Returns: dictionary of constraints created, keyed by `.centerX, .centerY`
-    public func constrainCenter(
+    @discardableResult public func constrainCenter(
         _ center: Center = .all,
         to view2: Anchorable? = nil,
         relatedBy relation: NSLayoutConstraint.Relation = .equal,


### PR DESCRIPTION
## Introduction ##

All our constrain auto layout methods are supposed to return layout constraints as discardable (99% of the time the caller doesn't need to reference them further). `constrainCenter` breaks this pattern by not being marked discardable (an oversight and a failure in the original PR to add this feature).

## Purpose ##

Mark `constrainCenter` method return value as discardable

## Scope ##

* Modify `constrainCenter` func

## Discussion ##

This was intended to be part of the original ticket but got overlooked. I tried to use the new constrainCenter method in a sample app and the compiler complained that the return type was unused, which alerted me to the mistake.

Resolves #27 

## 📈 Coverage ##

Nothing should change since we're just adding an attribute to one function.