### PR TITLE
Make `Localizable`'s default implementation of `tableName` public

### DIFF
--- a/Sources/YCoreUI/Protocols/Localizable.swift
+++ b/Sources/YCoreUI/Protocols/Localizable.swift
@@ -32,5 +32,5 @@ extension Localizable {
     
     /// The name of the `.strings` file containing the localized strings for this enum.
     /// Returns `nil` to use the default `Localizable.strings` file
-    static var tableName: String? { nil }
+    public static var tableName: String? { nil }
 }


### PR DESCRIPTION
## Introduction ##

We added a default implementation for the new `tableName` property in the `Localizable` protocol but failed to mark it `public`. So now any one using `Localizable` has to implement `tableName` on every enum, which is unacceptable (breaking change).

## Purpose ##

Fix the issue with `Localizable.tableName`

## Scope ##

* mark computed property as `public`
* fix SwiftLint warnings for latest release of SwiftLint

## Discussion ##

Resolves #31 

## 📈 Coverage ##

##### Code: 100% #####

<img width="551" alt="image" src="https://user-images.githubusercontent.com/1037520/203400971-4e56b78e-5728-4210-801f-2293d4f1925b.png">

##### Documentation: 100% #####

<img width="566" alt="image" src="https://user-images.githubusercontent.com/1037520/203401208-175579b4-71f8-467c-a111-ec500d2b5335.png">