### PR TITLE
[CM-995] Add new linter rules and fix warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,8 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count
   - first_where
   - force_unwrapping
+  - implicit_return
+  - missing_docs
   - multiline_arguments
   - multiline_arguments_brackets
   - multiline_function_chains

--- a/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbComponents.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbComponents.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+// This relatively simple tuple (four float values representing the color channels)
+// is already a released public api.
+// swiftlint: disable large_tuple
+
 /// Tuple representing Red, Green, Blue, and Alpha color channel components
 public typealias RGBAComponents = (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
 

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainEdges.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainEdges.swift
@@ -10,22 +10,22 @@ import UIKit
 
 extension NSDirectionalRectEdge {
     /// Horizontal edges only (consisting of `.leading` and `.trailing`)
-    public static var horizontal: NSDirectionalRectEdge { return [.leading, .trailing] }
+    public static var horizontal: NSDirectionalRectEdge { [.leading, .trailing] }
 
     /// Vertical edges only (consisting of `.top` and `.bottom`)
-    public static var vertical: NSDirectionalRectEdge { return [.top, .bottom] }
+    public static var vertical: NSDirectionalRectEdge { [.top, .bottom] }
 
     /// All edges except `.top`
-    public static var notTop: NSDirectionalRectEdge { return [.leading, .bottom, .trailing] }
+    public static var notTop: NSDirectionalRectEdge { [.leading, .bottom, .trailing] }
 
     /// All edges except `.leading`
-    public static var notLeading: NSDirectionalRectEdge { return [.top, .bottom, .trailing] }
+    public static var notLeading: NSDirectionalRectEdge { [.top, .bottom, .trailing] }
 
     /// All edges except `.bottom`
-    public static var notBottom: NSDirectionalRectEdge { return [.top, .leading, .trailing] }
+    public static var notBottom: NSDirectionalRectEdge { [.top, .leading, .trailing] }
 
     /// All edges except `.trailing`
-    public static var notTrailing: NSDirectionalRectEdge { return [.top, .leading, .bottom] }
+    public static var notTrailing: NSDirectionalRectEdge { [.top, .leading, .bottom] }
 }
 
 extension UIView {

--- a/Tests/YCoreUITests/Extensions/Foundation/CGFloat+roundedTests.swift
+++ b/Tests/YCoreUITests/Extensions/Foundation/CGFloat+roundedTests.swift
@@ -9,6 +9,9 @@
 import XCTest
 @testable import YCoreUI
 
+// Large tuples help us build unit test expectations concisely
+// swiftlint:disable large_tuple
+
 final class CGFloatRoundedTests: XCTestCase {
     typealias ScalingInputs = (
         value: CGFloat,

--- a/Tests/YCoreUITests/Extensions/UIKit/UIColor+WCAGTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIColor+WCAGTests.swift
@@ -9,6 +9,9 @@
 import XCTest
 @testable import YCoreUI
 
+// Large tuples help us build unit test expectations concisely
+// swiftlint:disable large_tuple
+
 final class UIColorWCAGTests: XCTestCase {
     typealias ColorInputs = (foreground: UIColor, background: UIColor, context: WCAGContext)
 

--- a/Tests/YCoreUITests/Extensions/UIKit/UIColor+rgbValueTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIColor+rgbValueTests.swift
@@ -8,6 +8,9 @@
 
 import XCTest
 
+// Large tuples help us build unit test expectations concisely
+// swiftlint:disable large_tuple
+
 final class UIColorRgbValueTests: XCTestCase {
     typealias ColorTest = (color: UIColor, prefix: String?, isUppercase: Bool, output: String)
 

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAnchorTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAnchorTests.swift
@@ -9,9 +9,6 @@
 import XCTest
 @testable import YCoreUI
 
-// It's not a problem having too many tests!
-// swiftlint:disable type_body_length
-
 final class UIViewConstrainAnchorTests: XCTestCase {
     func testXAxisConstraints() {
         let (sut, relations) = makeSUT()

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainEdgesTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainEdgesTests.swift
@@ -8,9 +8,6 @@
 
 import XCTest
 
-// It's not a problem having too many tests!
-// swiftlint:disable function_body_length
-
 final class UIViewConstrainEdgesTests: XCTestCase {
     func testSimple() {
         let (sut, insets) = makeSUT()

--- a/Tests/YCoreUITests/Foundations/UIColor+TestHarness.swift
+++ b/Tests/YCoreUITests/Foundations/UIColor+TestHarness.swift
@@ -46,9 +46,6 @@ extension UIColor {
 }
 
 extension UIColor {
-    /// 0x0067B1
-    static let brand = UIColor(rgb: 0x0067B1)
-
     /// 0x0050AC
     static let interactive = UIColor(rgb: 0x0050AC)
 
@@ -57,9 +54,6 @@ extension UIColor {
 
     /// 0xE7F3FE
     static let shade2 = UIColor(rgb: 0xE7F3FE)
-
-    /// 0x6390BC
-    static let shade3 = UIColor(rgb: 0x6390BC)
 }
 
 extension UIColor {
@@ -113,17 +107,6 @@ extension UIColor {
             }
         }
 
-    static let separatorSecondary: UIColor =
-        UIColor { (traitCollection: UITraitCollection) -> UIColor in
-            switch(traitCollection.userInterfaceStyle,
-                   traitCollection.accessibilityContrast) {
-            case (.dark, .high):    return .gray600
-            case (.dark, _):        return .gray500
-            case (_, .high):        return .gray600
-            default:                return .white
-            }
-        }
-
     static let backgroundPrimaryCTA: UIColor =
         UIColor { (traitCollection: UITraitCollection) -> UIColor in
             switch(traitCollection.userInterfaceStyle,
@@ -143,17 +126,4 @@ extension UIColor {
             default:                return .white
             }
         }
-
-    static let backgroundAccent: UIColor =
-        UIColor { (traitCollection: UITraitCollection) -> UIColor in
-            switch(traitCollection.userInterfaceStyle,
-                   traitCollection.accessibilityContrast) {
-            case (.dark, .high):    return .gray400
-            case (.dark, _):        return .gray300
-            case (_, .high):        return .accent.darkened(by: 0.25)
-            default:                return .accent
-            }
-        }
-
-    public static let contentAccent: UIColor = .white
 }


### PR DESCRIPTION
## Introduction
Our style guide requires the use of implicit return and our library team requires full documentation, so we should add linter rules to enforce these things instead of having to spot them during code review.

## Purpose
Update SwiftLint config with `implicit_return` and `missing_docs` rules. Fix any linter violations.

## Scope
* Update `.swiftlint.yml`
* Fix linter violations

## Discussion
YCoreUI had some violations of the `implicit_return` rule. 

The other changes come from changes to a recent version of SwiftLint (0.50.1) which altered the behavior of the `body_length`, and `file_length` rules. There’s also a new change in how SwiftLint enforces the `large_tuple` rule. I just disabled it for the unit tests in question. (Not worth declaring specialty struct’s in this case in my opinion.) There’s also one use in the source code in the `UIColor` extension that parses out the rgba channel values. I didn’t want to change that and a struct seemed super heavy compared to a tuple of 4 float values.

I also deleted some unused colors that were being declared for unit tests (one of the deleted color triggered the `missing_docs` rule because it had been declared as `public`).

We want to roll out these changes to all of our YML libraries, both in Bitbucket and on GitHub.

Fixes Issue #33 

## 📈 Coverage
Unchanged. And documentation coverage should now be enforced by the linter!

