### PR TITLE
[CM-1012] Add `constrainAspectRatio` method to UIView extension.

### DIFF
--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
@@ -1,0 +1,9 @@
+//
+//  UIView+constrainAspectRatio.swift
+//  YCoreUI
+//
+//  Created by Dev Karan on 14/12/22.
+//  Copyright © 2022 Y Media Labs. All rights reserved.
+//
+
+import UIKit

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
@@ -7,3 +7,31 @@
 //
 
 import UIKit
+
+extension UIView {
+    /// constrain the aspect ratio for the receiving view
+    /// - Parameters:
+    ///   - ratio: aspect ratio
+    ///   - offset: offset to apply (default `.zero`)
+    ///   - relation: relation to evaluate (towards dimension) (default `.equal`)
+    ///   - priority: constraint priority (default `.required`)
+    ///   - isActive: whether to activate the constraint or not (default `true`)
+    /// - Returns: The created layout constraint
+    @discardableResult public func constrainAspectRatio(
+        _ ratio: CGFloat,
+        offset: CGFloat = 0,
+        relatedBy relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required,
+        isActive: Bool = true
+    ) -> NSLayoutConstraint {
+        constrain(
+            .widthAnchor,
+            to : heightAnchor,
+            relatedBy : relation,
+            multiplier: ratio,
+            constant : offset,
+            priority: priority,
+            isActive: isActive
+        )
+    }
+}

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
@@ -9,14 +9,14 @@
 import UIKit
 
 extension UIView {
-    /// constrain the aspect ratio for the receiving view
+    /// Constrain the aspect ratio for the receiving view.
     /// - Parameters:
     ///   - ratio: aspect ratio
     ///   - offset: offset to apply (default `.zero`)
     ///   - relation: relation to evaluate (towards dimension) (default `.equal`)
     ///   - priority: constraint priority (default `.required`)
     ///   - isActive: whether to activate the constraint or not (default `true`)
-    /// - Returns: The created layout constraint
+    /// - Returns: the created layout constraint
     @discardableResult public func constrainAspectRatio(
         _ ratio: CGFloat,
         offset: CGFloat = 0,

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
@@ -26,10 +26,10 @@ extension UIView {
     ) -> NSLayoutConstraint {
         constrain(
             .widthAnchor,
-            to : heightAnchor,
-            relatedBy : relation,
+            to: heightAnchor,
+            relatedBy: relation,
             multiplier: ratio,
-            constant : offset,
+            constant: offset,
             priority: priority,
             isActive: isActive
         )

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainAspectRatio.swift
@@ -13,7 +13,7 @@ extension UIView {
     /// - Parameters:
     ///   - ratio: aspect ratio
     ///   - offset: offset to apply (default `.zero`)
-    ///   - relation: relation to evaluate (towards dimension) (default `.equal`)
+    ///   - relation: relation to evaluate (towards ratio) (default `.equal`)
     ///   - priority: constraint priority (default `.required`)
     ///   - isActive: whether to activate the constraint or not (default `true`)
     /// - Returns: the created layout constraint

--- a/Sources/YCoreUI/Extensions/UIKit/UIView+constrainSize.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIView+constrainSize.swift
@@ -41,7 +41,7 @@ extension UIView {
         return [.width: widthConstraint, .height: heightConstraint]
     }
     
-    /// Constrain the receiving view with width and heigh
+    /// Constrain the receiving view with width and height
     /// - Parameters:
     ///   - width: width of view to constrain to
     ///   - height: height of view to constrain to

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
@@ -71,4 +71,3 @@ private extension UIViewContrainAspectRatioTests {
         return sut
     }
 }
-

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
@@ -10,27 +10,61 @@ import XCTest
 @testable import YCoreUI
 
 final class UIViewContrainAspectRatioTests: XCTestCase {
-    func testSimple() {
+    func test_constrainAspectRatio_deliversDefaultValues() {
+        // Arrange
         let sut = makeSUT()
-        XCTAssert(sut.translatesAutoresizingMaskIntoConstraints)
-        sut.frame = CGRect(x: 0, y: 0, width: 100, height: 500)
-        sut.constrainAspectRatio(0.5)
-//        XCTAssertEqual(sut.frame.height, sut.frame.width * 0.5)
+        // Act
+        let constraint = sut.constrainAspectRatio(0.5)
+        // Assert
+        XCTAssertEqual(constraint.constant, .zero)
+        XCTAssertEqual(constraint.priority, .required)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .width)
+        XCTAssertEqual(constraint.secondAttribute, .height)
     }
     
-    func testOffset() {
+    func test_constrainAspectRatio_translatesAutoResizingMaskIsFalse() {
+        // Arrange
         let sut = makeSUT()
-        var randomOffset: CGFloat = CGFloat.random(in: 0..<500)
-        let constraint = sut.constrainAspectRatio(0.5, offset: randomOffset)
-        XCTAssertEqual(constraint.constant, randomOffset)
+        // Act
+        sut.constrainAspectRatio(0.5)
+        // Assert
+        XCTAssertFalse(sut.translatesAutoresizingMaskIntoConstraints)
     }
-        
-    func testPriority() {
+    
+    func test_constrainAspectRatio_deliversMultiplierForTheGivenRatio() {
+        // Arrange
         let sut = makeSUT()
-        let randomPriority: UILayoutPriority = UILayoutPriority(Float.random(in: 1...1000))
-        let constraint = sut.constrainAspectRatio(0.5, priority: randomPriority)
-        XCTAssertEqual(constraint.priority, randomPriority)
+        // Act
+        let constraint = sut.constrainAspectRatio(0.5)
+        // Assert
+        XCTAssertEqual(constraint.multiplier, 0.5)
     }
+    
+//    func test_constrainAspectRatio_layoutsSUT() {
+//        // Arrange
+//        let containerView = UIView()
+//        containerView.translatesAutoresizingMaskIntoConstraints = false
+//
+//        containerView.heightAnchor.constraint(equalToConstant: 500).isActive = true
+//        containerView.widthAnchor.constraint(equalToConstant: 500).isActive = true
+//
+//        containerView.layoutIfNeeded()
+//
+//
+//
+//        let sut = makeSUT()
+//
+//        // Act
+//        sut.constrainAspectRatio(0.5)
+//
+//        sut.layoutIfNeeded()
+//
+//
+//
+//        XCTAssertEqual(sut.frame.height, sut.frame.width * 0.5)
+//    }
 }
 
 private extension UIViewContrainAspectRatioTests {

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
@@ -10,5 +10,37 @@ import XCTest
 @testable import YCoreUI
 
 final class UIViewContrainAspectRatioTests: XCTestCase {
+    func testSimple() {
+        let sut = makeSUT()
+        XCTAssert(sut.translatesAutoresizingMaskIntoConstraints)
+        sut.frame = CGRect(x: 0, y: 0, width: 100, height: 500)
+        sut.constrainAspectRatio(0.5)
+//        XCTAssertEqual(sut.frame.height, sut.frame.width * 0.5)
+    }
     
+    func testOffset() {
+        let sut = makeSUT()
+        var randomOffset: CGFloat = CGFloat.random(in: 0..<500)
+        let constraint = sut.constrainAspectRatio(0.5, offset: randomOffset)
+        XCTAssertEqual(constraint.constant, randomOffset)
+    }
+        
+    func testPriority() {
+        let sut = makeSUT()
+        let randomPriority: UILayoutPriority = UILayoutPriority(Float.random(in: 1...1000))
+        let constraint = sut.constrainAspectRatio(0.5, priority: randomPriority)
+        XCTAssertEqual(constraint.priority, randomPriority)
+    }
 }
+
+private extension UIViewContrainAspectRatioTests {
+    func makeSUT(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> UIView {
+        let sut = UIView()
+        trackForMemoryLeak(sut, file: file, line: line)
+        return sut
+    }
+}
+

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
@@ -49,14 +49,12 @@ final class UIViewContrainAspectRatioTests: XCTestCase {
         let sut = makeSUT()
         containerView.addSubview(sut)
         
-        let ratio: CGFloat = 0.5
+        let ratio: CGFloat = 0.7
         let height: CGFloat = 300
         sut.constrain(.heightAnchor, constant: height)
-        
         // Act
         sut.constrainAspectRatio(ratio)
         sut.layoutIfNeeded()
-
         // Assert
         XCTAssertEqual(sut.bounds.width, ratio * sut.bounds.height)
         XCTAssertEqual(sut.bounds.height, height)

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
@@ -24,7 +24,7 @@ final class UIViewContrainAspectRatioTests: XCTestCase {
         XCTAssertEqual(constraint.secondAttribute, .height)
     }
     
-    func test_constrainAspectRatio_translatesAutoResizingMaskIsFalse() {
+    func test_constrainAspectRatio_translatesAutoresizingMaskIntoConstraintsIsFalse() {
         // Arrange
         let sut = makeSUT()
         // Act
@@ -33,38 +33,34 @@ final class UIViewContrainAspectRatioTests: XCTestCase {
         XCTAssertFalse(sut.translatesAutoresizingMaskIntoConstraints)
     }
     
-    func test_constrainAspectRatio_deliversMultiplierForTheGivenRatio() {
+    func test_constrainAspectRatio_multiplierAndRatioMatches() {
         // Arrange
         let sut = makeSUT()
+        let ratio = 0.5
         // Act
-        let constraint = sut.constrainAspectRatio(0.5)
+        let constraint = sut.constrainAspectRatio(ratio)
         // Assert
-        XCTAssertEqual(constraint.multiplier, 0.5)
+        XCTAssertEqual(constraint.multiplier, ratio)
     }
     
-//    func test_constrainAspectRatio_layoutsSUT() {
-//        // Arrange
-//        let containerView = UIView()
-//        containerView.translatesAutoresizingMaskIntoConstraints = false
-//
-//        containerView.heightAnchor.constraint(equalToConstant: 500).isActive = true
-//        containerView.widthAnchor.constraint(equalToConstant: 500).isActive = true
-//
-//        containerView.layoutIfNeeded()
-//
-//
-//
-//        let sut = makeSUT()
-//
-//        // Act
-//        sut.constrainAspectRatio(0.5)
-//
-//        sut.layoutIfNeeded()
-//
-//
-//
-//        XCTAssertEqual(sut.frame.height, sut.frame.width * 0.5)
-//    }
+    func test_constrainAspectRatio_resizesSUTWithGivenRatio() {
+        // Arrange
+        let containerView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 500, height: 500)))
+        let sut = makeSUT()
+        containerView.addSubview(sut)
+        
+        let ratio: CGFloat = 0.5
+        let height: CGFloat = 300
+        sut.constrain(.heightAnchor, constant: height)
+        
+        // Act
+        sut.constrainAspectRatio(ratio)
+        sut.layoutIfNeeded()
+
+        // Assert
+        XCTAssertEqual(sut.bounds.width, ratio * sut.bounds.height)
+        XCTAssertEqual(sut.bounds.height, height)
+    }
 }
 
 private extension UIViewContrainAspectRatioTests {

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import YCoreUI
+import YCoreUI
 
 final class UIViewContrainAspectRatioTests: XCTestCase {
     func test_constrainAspectRatio_deliversDefaultValues() {

--- a/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIView+constrainAspectRatioTests.swift
@@ -1,0 +1,14 @@
+//
+//  UIView+constrainAspectRatioTests.swift
+//  YCoreUI
+//
+//  Created by Dev Karan on 14/12/22.
+//  Copyright © 2022 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YCoreUI
+
+final class UIViewContrainAspectRatioTests: XCTestCase {
+    
+}


### PR DESCRIPTION
## Introduction ##

Add `constrainAspectRatio` method to UIView extension.

## Purpose ##

Creates a constraint on the receiving view, constraining its widthAnchor to its heightAnchor using ratio as the multiplier and optional offset as the constant.

## Scope ##

Updated production code and Test code.

## 📈 Coverage ##

##### Code #####

<img width="1132" alt="Screenshot 2022-12-15 at 2 50 14 PM" src="https://user-images.githubusercontent.com/102538361/207827695-9aa7fe96-81b6-458d-af80-0e95f9bd17c3.png">

