### PR TITLE
[Issue-51] Log warnings when fallback image is delivered.

### DIFF
--- a/Sources/YCoreUI/Protocols/ImageAsset.swift
+++ b/Sources/YCoreUI/Protocols/ImageAsset.swift
@@ -60,17 +60,30 @@ extension ImageAsset {
     /// (prepended to `rawValue`) and `bundle`.
     /// - Returns: The named image or else `nil` if the named asset cannot be loaded.
     public func loadImage() -> UIImage? {
+        UIImage(named: calculateName(), in: Self.bundle, compatibleWith: nil)
+    }
+
+    internal func calculateName() -> String {
         let name: String
         if let validNamespace = Self.namespace {
             name = "\(validNamespace)/\(rawValue)"
         } else {
             name = rawValue
         }
-        return UIImage(named: name, in: Self.bundle, compatibleWith: nil)
+        return name
     }
     
     /// An image asset for this name value.
     ///
     /// Default implementation calls `loadImage` and nil-coalesces to `fallbackImage`.
-    public var image: UIImage { loadImage() ?? Self.fallbackImage }
+    public var image: UIImage {
+        guard let image = loadImage() else {
+            if YCoreUI.isLoggingEnabled {
+                YCoreUI.imageLogger.warning("Image named \(calculateName()) failed to load from bundle.")
+            }
+            return Self.fallbackImage
+        }
+
+        return image
+    }
 }

--- a/Sources/YCoreUI/Protocols/SystemImage.swift
+++ b/Sources/YCoreUI/Protocols/SystemImage.swift
@@ -50,5 +50,14 @@ extension SystemImage {
     /// A system image for this name value.
     ///
     /// Default implementation calls `loadImage` and nil-coalesces to `fallbackImage`.
-    public var image: UIImage { loadImage() ?? Self.fallbackImage }
+    public var image: UIImage {
+        guard let image = loadImage() else {
+            if YCoreUI.isLoggingEnabled {
+                YCoreUI.imageLogger.warning("System image named \(rawValue) failed to load.")
+            }
+            return Self.fallbackImage
+        }
+
+        return image
+    }
 }

--- a/Sources/YCoreUI/YCoreUI+Logging.swift
+++ b/Sources/YCoreUI/YCoreUI+Logging.swift
@@ -1,0 +1,21 @@
+//
+//  YCoreUI+Logging.swift
+//  YCoreUI
+//
+//  Created by Mark Pospesel on 3/16/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import Foundation
+import os
+
+/// Y—CoreUI Settings
+public struct YCoreUI {
+    /// Whether console logging for warnings is enabled. Defaults to `true`.
+    public static var isLoggingEnabled = true
+}
+
+internal extension YCoreUI {
+    /// Logger for warnings related to image loading. cf. `ImageAsset` and `SystemImage`
+    static let imageLogger = Logger(subsystem: "YCoreUI", category: "images")
+}

--- a/Tests/YCoreUITests/Protocols/ImageAssetTests.swift
+++ b/Tests/YCoreUITests/Protocols/ImageAssetTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import YCoreUI
+@testable import YCoreUI
 
 final class ImageAssetTests: XCTestCase {
     func test_bundle() {
@@ -37,20 +37,35 @@ final class ImageAssetTests: XCTestCase {
     func test_loadImageWithoutNameSpace() {
         Flags.allCases.forEach {
             XCTAssertNotNil($0.loadImage())
+            XCTAssertNotEqual($0.image.pngData(), DefaultImageAssets.fallbackImage.pngData())
         }
     }
     
     func test_missingImage() {
+        YCoreUI.isLoggingEnabled = false
+
         Missing.allCases.forEach {
             XCTAssertNil($0.loadImage())
             XCTAssertEqual($0.image, UIImage(systemName: "x.squareroot"))
         }
+
+        YCoreUI.isLoggingEnabled = true
     }
     
     func test_imageAsset_defaultValues() {
         XCTAssertEqual(DefaultImageAssets.bundle, .main)
         XCTAssertEqual(DefaultImageAssets.defaultCase.image.pngData(), DefaultImageAssets.fallbackImage.pngData())
         XCTAssertNil(DefaultImageAssets.namespace)
+    }
+
+    func test_calculateName_deliversCorrectName() {
+        Flags.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), $0.rawValue)
+        }
+
+        Icons.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), "Icons/\($0.rawValue)")
+        }
     }
 }
 

--- a/Tests/YCoreUITests/Protocols/SystemImageTests.swift
+++ b/Tests/YCoreUITests/Protocols/SystemImageTests.swift
@@ -18,14 +18,19 @@ final class SystemImageTests: XCTestCase {
     func test_loadImage_deliversImage() {
         Symbols.allCases.forEach {
             XCTAssertNotNil($0.loadImage())
+            XCTAssertNotEqual($0.image.pngData(), DefaultSymbols.fallbackImage.pngData())
         }
     }
 
     func test_missingImage_deliversCustomFallback() {
+        YCoreUI.isLoggingEnabled = false
+
         MissingSymbols.allCases.forEach {
             XCTAssertNil($0.loadImage())
             XCTAssertEqual($0.image, UIImage(systemName: "x.squareroot"))
         }
+
+        YCoreUI.isLoggingEnabled = true
     }
 
     func test_systemImage_deliversDefaultFallback() {

--- a/Tests/YCoreUITests/YCoreUI+LoggingTests.swift
+++ b/Tests/YCoreUITests/YCoreUI+LoggingTests.swift
@@ -1,0 +1,16 @@
+//
+//  YCoreUI+LoggingTests.swift
+//  YCoreUI
+//
+//  Created by Mark Pospesel on 3/16/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YCoreUI
+
+final class YCoreUILoggingTests: XCTestCase {
+    func testDefaults() {
+        XCTAssertTrue(YCoreUI.isLoggingEnabled)
+    }
+}


### PR DESCRIPTION
## Introduction ##

When either `ImageAsset` or `SystemImage` fails to load an image and delivers the fallback image instead we should log a warning to the console to alert the developer.

## Purpose ##

Fix #51: Optionally log warning to console when delivering the fallback image.

## Scope ##

* Add logging to `ImageAsset.image`
* Add logging to `SystemImage.image`
* Add a logger singleton plus a flag to optionally silence it.
* Unit tests

## 📈 Coverage ##

##### Code #####

100%
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1037520/225692875-e39a97c0-9000-49ab-b0f1-47a78b90a480.png">

##### Documentation #####

100%
<img width="554" alt="image" src="https://user-images.githubusercontent.com/1037520/225693050-edb9033a-9f47-4918-92c6-7d58e7ed7b18.png">
