### PR TITLE
[Issue-46] Clamp sRGB display values

### DIFF
--- a/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbValue.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbValue.swift
@@ -17,12 +17,19 @@ public extension UIColor {
     func rgbDisplayString(prefix: String? = nil, isUppercase: Bool = true) -> String {
         let comp = rgbaComponents
         let format = isUppercase ? "%02X%02X%02X" : "%02x%02x%02x"
+        let r = Int(round(comp.red * 255))
+        let g = Int(round(comp.green * 255))
+        let b = Int(round(comp.blue * 255))
+        let isRGB = (r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)
         let value = String(
             format: format,
-            Int(round(comp.red * 255)),
-            Int(round(comp.green * 255)),
-            Int(round(comp.blue * 255))
+            min(max(r, 0), 255),
+            min(max(g, 0), 255),
+            min(max(b, 0), 255)
         )
-        return "\(prefix ?? "")\(value)"
+        if !isRGB && YCoreUI.isLoggingEnabled {
+            YCoreUI.colorLogger.warning("Color \(self) falls outside of the sRGB color space.")
+        }
+        return "\(prefix ?? "")\(value)\(isRGB ? "" : "⚠️")"
     }
 }

--- a/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbValue.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbValue.swift
@@ -15,6 +15,19 @@ public extension UIColor {
     ///   - isUppercase: whether the hex values should be upper or lower case
     /// - Returns: the formatted hexadecimal string
     func rgbDisplayString(prefix: String? = nil, isUppercase: Bool = true) -> String {
+        _rgbDisplayString(prefix: prefix, isUppercase: isUppercase, isDebug: false)
+    }
+
+    /// Formats a color as an RGB hexadecimal string. Appropriate for debug printing.
+    /// - Parameters:
+    ///   - prefix: optional prefix to precede the hexadecimal value such as `0x` or `#` (default = nil)
+    ///   - isUppercase: whether the hex values should be upper or lower case
+    /// - Returns: the formatted hexadecimal string (with an `⚠️` for colors that fall outside of the sRGB color space)
+    func rgbDebugDisplayString(prefix: String? = nil, isUppercase: Bool = true) -> String {
+        _rgbDisplayString(prefix: prefix, isUppercase: isUppercase, isDebug: true)
+    }
+
+    private func _rgbDisplayString(prefix: String?, isUppercase: Bool, isDebug: Bool) -> String {
         let comp = rgbaComponents
         let format = isUppercase ? "%02X%02X%02X" : "%02x%02x%02x"
         let r = Int(round(comp.red * 255))
@@ -30,6 +43,6 @@ public extension UIColor {
         if !isRGB && YCoreUI.isLoggingEnabled {
             YCoreUI.colorLogger.warning("Color \(self) falls outside of the sRGB color space.")
         }
-        return "\(prefix ?? "")\(value)\(isRGB ? "" : "⚠️")"
+        return "\(prefix ?? "")\(value)\(isDebug && !isRGB ? "⚠️" : "")"
     }
 }

--- a/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbValue.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIColor+rgbValue.swift
@@ -34,15 +34,17 @@ public extension UIColor {
         let g = Int(round(comp.green * 255))
         let b = Int(round(comp.blue * 255))
         let isRGB = (r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)
+        let prefix = prefix ?? ""
         let value = String(
             format: format,
             min(max(r, 0), 255),
             min(max(g, 0), 255),
             min(max(b, 0), 255)
         )
+        let suffix = (isDebug && !isRGB) ? "⚠️" : ""
         if !isRGB && YCoreUI.isLoggingEnabled {
             YCoreUI.colorLogger.warning("Color \(self) falls outside of the sRGB color space.")
         }
-        return "\(prefix ?? "")\(value)\(isDebug && !isRGB ? "⚠️" : "")"
+        return "\(prefix)\(value)\(suffix)"
     }
 }

--- a/Sources/YCoreUI/YCoreUI+Logging.swift
+++ b/Sources/YCoreUI/YCoreUI+Logging.swift
@@ -18,4 +18,6 @@ public struct YCoreUI {
 internal extension YCoreUI {
     /// Logger for warnings related to image loading. cf. `ImageAsset` and `SystemImage`
     static let imageLogger = Logger(subsystem: "YCoreUI", category: "images")
+    /// Logger for warnings related to colors. cf `UIColor+rgbValue.swift`
+    static let colorLogger = Logger(subsystem: "YCoreUI", category: "colors")
 }

--- a/Tests/YCoreUITests/Extensions/UIKit/UIColor+rgbValueTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIColor+rgbValueTests.swift
@@ -47,6 +47,8 @@ final class UIColorRgbValueTests: XCTestCase {
     func testSuffixes() {
         testCases.forEach {
             XCTAssertFalse($0.color.rgbDisplayString().hasSuffix("⚠️"))
+            XCTAssertFalse($0.color.rgbDebugDisplayString().hasSuffix("⚠️"))
+            XCTAssertEqual($0.color.rgbDisplayString(), $0.color.rgbDebugDisplayString())
         }
 
         let p3Colors = [
@@ -65,7 +67,8 @@ final class UIColorRgbValueTests: XCTestCase {
         ]
 
         p3Colors.forEach {
-            XCTAssertTrue($0.rgbDisplayString().hasSuffix("⚠️"))
+            XCTAssertFalse($0.rgbDisplayString().hasSuffix("⚠️"))
+            XCTAssertTrue($0.rgbDebugDisplayString().hasSuffix("⚠️"))
             YCoreUI.isLoggingEnabled = false
         }
 

--- a/Tests/YCoreUITests/Extensions/UIKit/UIColor+rgbValueTests.swift
+++ b/Tests/YCoreUITests/Extensions/UIKit/UIColor+rgbValueTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import YCoreUI
 
 // Large tuples help us build unit test expectations concisely
 // swiftlint:disable large_tuple
@@ -41,5 +42,33 @@ final class UIColorRgbValueTests: XCTestCase {
 
         // We exect each rgb color channel value to be rounded appropriately
         XCTAssertEqual(color.rgbDisplayString(), "80BFA6")
+    }
+
+    func testSuffixes() {
+        testCases.forEach {
+            XCTAssertFalse($0.color.rgbDisplayString().hasSuffix("⚠️"))
+        }
+
+        let p3Colors = [
+            UIColor(displayP3Red: 1, green: 0, blue: 0, alpha: 1),
+            UIColor(displayP3Red: 0, green: 1, blue: 0, alpha: 1),
+            UIColor(displayP3Red: 0, green: 0, blue: 1, alpha: 1),
+            UIColor(displayP3Red: 1, green: 1, blue: 0, alpha: 1),
+            UIColor(displayP3Red: 1, green: 0, blue: 1, alpha: 1),
+            UIColor(displayP3Red: 0, green: 1, blue: 1, alpha: 1),
+            UIColor(red: 1.25, green: 0, blue: 0, alpha: 1),
+            UIColor(red: 0, green: 1.25, blue: 0, alpha: 1),
+            UIColor(red: 0, green: 0, blue: 1.25, alpha: 1),
+            UIColor(red: -0.25, green: 0, blue: 0, alpha: 1),
+            UIColor(red: 0, green: -0.25, blue: 0, alpha: 1),
+            UIColor(red: 0, green: 0, blue: -0.25, alpha: 1)
+        ]
+
+        p3Colors.forEach {
+            XCTAssertTrue($0.rgbDisplayString().hasSuffix("⚠️"))
+            YCoreUI.isLoggingEnabled = false
+        }
+
+        YCoreUI.isLoggingEnabled = true
     }
 }


### PR DESCRIPTION
## Introduction ##

We format RGB values as hex without considering that with extended sRGB, channel values might be less than 0x00 or greater than 0xFF. We should restrict the values to this range but provide a warning.

## Purpose ##

Fix #46 Make sure displayed hex channel values are between 0x00 and 0xFF

## Scope ##

* Adjust implementation of `UIColor.rgbDisplayValue()`
* Add test coverage

## Discussion ##

When a value falls outside of the range, we will clamp it to 0x00-0xFF and log a console warning (unless logging has been disabled). This adopts a similar logging mechanism to what we use when `ImageAsset` or `SystemImage` fails to load an image and must resort to the fallback.

For the newly added `rgbDebugDisplayValue()` method we will also append a "⚠️" emoji to the output string for colors that fall outside of the sRGB color space.

## 📱 Screenshots ##

| Before | After |
| ------------- | ------------- |
| <img width="375" alt="ycui_46_before" src="https://user-images.githubusercontent.com/1037520/226368847-9f250fc7-a3ed-42c9-91b7-545c14f67658.png"> | <img width="375" alt="ycui_46_after" src="https://user-images.githubusercontent.com/1037520/226368857-a8c7335f-b889-4f54-ae21-983c83a65576.png"> |

## 📈 Coverage ##

##### Code #####

100%
<img width="706" alt="image" src="https://user-images.githubusercontent.com/1037520/226366339-e97c1ca0-f002-41ff-92f6-6444a2b78053.png">

##### Documentation #####

100%
<img width="565" alt="image" src="https://user-images.githubusercontent.com/1037520/226366617-13d61626-5483-4bdd-9328-0c088cbd7a92.png">
