### PR TITLE
Account for transparency when calculating WCAG color contrast

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/YCoreUI.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/YCoreUI.xcscheme
@@ -58,7 +58,8 @@
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "YCoreUITests"

--- a/Sources/YCoreUI/Extensions/UIKit/UIColor+WCAG.swift
+++ b/Sources/YCoreUI/Extensions/UIKit/UIColor+WCAG.swift
@@ -97,7 +97,9 @@ extension UIColor {
             // can't calculate a contrast between two transparent colors
             if YCoreUI.isLoggingEnabled {
                 YCoreUI.colorLogger.warning(
-                    "Transparent color \(self) cannot calculate contrast ratio to other transparent color \(otherColor)."
+                    """
+                    Transparent color \(self) cannot calculate contrast ratio to other transparent color \(otherColor).
+                    """
                 )
             }
             return .nan


### PR DESCRIPTION
## Introduction ##

When we perform our color contrast checking, we only look at the RGB channels and not the A. When the foreground color has alpha, it becomes blended with the background color, and it is this blended color that we should perform the check against.

## Purpose ##

Fix #42 Account for transparency by:
1. returning `.nan` and logging a warning if we attempt to check contrast on two transparent colors (insufficient info)
2. if just one color is transparent, blend it with the other color and compare that blended color to the other color.

## Scope ##

* Adjustments to `UIColor.contrastRatio(to:)`

## Discussion ##

So the problem was we weren't considering alpha, so contrast between black at 50% opacity and white was same as that between solid black and white. When really that black would appear as `0x808080` gray and _that_ is the value we should be testing for contrast.

## 📈 Coverage ##

##### Code #####

100%
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1037520/226464222-5f2d98dd-6197-4208-889b-76181ad2963f.png">

##### Documentation #####

100%
<img width="563" alt="image" src="https://user-images.githubusercontent.com/1037520/226464373-e0e269a4-5172-4325-a8c8-ea04192efe8c.png">
