### PR TITLE
[CM-1245] Support scalable system image.

### DIFF
--- a/Sources/YCoreUI/Protocols/SystemImage.swift
+++ b/Sources/YCoreUI/Protocols/SystemImage.swift
@@ -21,6 +21,17 @@ public protocol SystemImage: RawRepresentable where RawValue == String {
     ///
     /// Default implementation calls `loadImage` and nil-coalesces to `fallbackImage`.
     var image: UIImage { get }
+    
+    /// Image will scale according to the specified text style.
+    ///
+    /// Default implementation is `.body`.
+    static var textStyle: UIFont.TextStyle? { get }
+    
+    /// Image configuration to be used in `loadImage()`.
+    ///
+    /// Default implementation is `UIImage.SymbolConfiguration(textStyle: textStyle)`.
+    /// Returns `nil` when `textStyle` is `nil`.
+    static var configuration: UIImage.Configuration? { get }
 
     /// Loads the named system image.
     /// - Returns: The named system image or else `nil` if the system image cannot be loaded.
@@ -28,6 +39,21 @@ public protocol SystemImage: RawRepresentable where RawValue == String {
 }
 
 extension SystemImage {
+    /// Image will scale according to the specified text style.
+    public static var textStyle: UIFont.TextStyle? {
+        .body
+    }
+    
+    /// Image configuration to be used in `loadImage()`.
+    ///
+    /// Returns `nil` when `textStyle` is `nil`.
+    public static var configuration: UIImage.Configuration? {
+        guard let textStyle = textStyle else {
+            return nil
+        }
+        return UIImage.SymbolConfiguration(textStyle: textStyle)
+    }
+    
     /// Fallback image to use in case a system image cannot be loaded.
     /// (default is a 16 x 16 square filled with `.systemPink`)
     public static var fallbackImage: UIImage {
@@ -44,7 +70,7 @@ extension SystemImage {
     /// Default implementation uses `UIImage(systemName:)` passing in the associated `rawValue`.
     /// - Returns: The named system image or else `nil` if the system image cannot be loaded.
     public func loadImage() -> UIImage? {
-        UIImage(systemName: rawValue)
+        UIImage(systemName: rawValue, withConfiguration: Self.configuration)
     }
 
     /// A system image for this name value.

--- a/Tests/YCoreUITests/Protocols/SystemImageTests.swift
+++ b/Tests/YCoreUITests/Protocols/SystemImageTests.swift
@@ -32,7 +32,22 @@ final class SystemImageTests: XCTestCase {
 
         YCoreUI.isLoggingEnabled = true
     }
-
+    
+    func test_defaultImageScaling() {
+        XCTAssertEqual(Symbols.textStyle, .body)
+        XCTAssertEqual(Symbols.configuration, UIImage.SymbolConfiguration(textStyle: .body))
+    }
+    
+    func test_imageWithoutScaling() {
+        XCTAssertNil(SymbolWithoutScaling.textStyle)
+        XCTAssertNil(SymbolWithoutScaling.configuration)
+    }
+    
+    func test_customImageScaling() {
+        XCTAssertEqual(SymbolCustomScaling.textStyle, .largeTitle)
+        XCTAssertEqual(SymbolCustomScaling.configuration, UIImage.SymbolConfiguration(textStyle: .largeTitle))
+    }
+    
     func test_systemImage_deliversDefaultFallback() {
         XCTAssertEqual(DefaultSymbols.defaultCase.image.pngData(), DefaultSymbols.fallbackImage.pngData())
     }
@@ -58,5 +73,17 @@ extension SystemImageTests {
 
     enum DefaultSymbols: String, CaseIterable, SystemImage {
         case defaultCase
+    }
+    
+    enum SymbolWithoutScaling: String, CaseIterable, SystemImage {
+        static var textStyle: UIFont.TextStyle?
+        
+        case checked = "checkmark.square"
+    }
+    
+    enum SymbolCustomScaling: String, CaseIterable, SystemImage {
+        static var textStyle: UIFont.TextStyle? { .largeTitle }
+        
+        case checked = "checkmark.square"
     }
 }


### PR DESCRIPTION
## Introduction ##

This allows the system image scaling according to the specified text style when Dynamic Type changes

## Purpose ##

- Scaling system image according to the specified text style when Dynamic Type change.
- Fix #50

## Scope ##

Introduced two new properties `textStyle` and `configuration` in `SystemImage` protocol. By default system images will scale according to `.body`.

## 📈 Coverage ##

##### Code #####

<img width="939" alt="Screenshot 2023-03-23 at 5 14 45 PM" src="https://user-images.githubusercontent.com/102538361/227193824-3e493a11-f75d-480d-aa26-bf675ad07348.png">


##### Documentation #####

<img width="786" alt="Screenshot 2023-03-23 at 5 13 32 PM" src="https://user-images.githubusercontent.com/102538361/227193537-139128f8-7549-48bf-8945-2c1522e983d9.png">
