### PR TITLE
[CM-1324] Add logger for fallbackColor

### DIFF
--- a/Sources/YCoreUI/Protocols/Colorable.swift
+++ b/Sources/YCoreUI/Protocols/Colorable.swift
@@ -53,17 +53,29 @@ extension Colorable {
     /// (prepended to `rawValue`) and `bundle`.
     /// - Returns: The named color or else `nil` if the named asset cannot be loaded
     public func loadColor() -> UIColor? {
+        UIColor(named: calculateName(), in: Self.bundle, compatibleWith: nil)
+    }
+
+    internal func calculateName() -> String {
         let name: String
         if let validNamespace = Self.namespace {
             name = "\(validNamespace)/\(rawValue)"
         } else {
             name = rawValue
         }
-        return UIColor(named: name, in: Self.bundle, compatibleWith: nil)
+        return name
     }
     
     /// A color asset for this name value.
     ///
-    /// Default implementation calls `loadColor` and nil-coalesces to `fallbackColor`.
-    public var color: UIColor { loadColor() ?? Self.fallbackColor }
+    /// Returns `loadColor()` nil-coalesced to `fallbackColor`.
+    public var color: UIColor {
+        guard let color = loadColor() else {
+            if YCoreUI.isLoggingEnabled {
+                YCoreUI.colorLogger.warning("Color named \(calculateName()) failed to load from bundle.")
+            }
+            return Self.fallbackColor
+        }
+        return color
+    }
 }

--- a/Sources/YCoreUI/Protocols/Colorable.swift
+++ b/Sources/YCoreUI/Protocols/Colorable.swift
@@ -53,17 +53,29 @@ extension Colorable {
     /// (prepended to `rawValue`) and `bundle`.
     /// - Returns: The named color or else `nil` if the named asset cannot be loaded
     public func loadColor() -> UIColor? {
+        UIColor(named: calculateName(), in: Self.bundle, compatibleWith: nil)
+    }
+
+    internal func calculateName() -> String {
         let name: String
         if let validNamespace = Self.namespace {
             name = "\(validNamespace)/\(rawValue)"
         } else {
             name = rawValue
         }
-        return UIColor(named: name, in: Self.bundle, compatibleWith: nil)
+        return name
     }
     
     /// A color asset for this name value.
     ///
     /// Default implementation calls `loadColor` and nil-coalesces to `fallbackColor`.
-    public var color: UIColor { loadColor() ?? Self.fallbackColor }
+    public var color: UIColor {
+        guard let color = loadColor() else {
+            if YCoreUI.isLoggingEnabled {
+                YCoreUI.colorLogger.warning("Color named \(calculateName()) failed to load from bundle.")
+            }
+            return Self.fallbackColor
+        }
+        return color
+    }
 }

--- a/Tests/YCoreUITests/Protocols/ColorableTests.swift
+++ b/Tests/YCoreUITests/Protocols/ColorableTests.swift
@@ -31,20 +31,44 @@ final class ColorableTests: XCTestCase {
     func testLoadColorWithoutNamespace() {
         WarningColors.allCases.forEach {
             XCTAssertNotNil($0.loadColor())
+            XCTAssertNotEqual($0.color, WarningColors.fallbackColor)
         }
     }
 
     func testLoadColorWithNamespace() {
         ErrorColors.allCases.forEach {
             XCTAssertNotNil($0.loadColor())
+            XCTAssertNotEqual($0.color, ErrorColors.fallbackColor)
         }
     }
 
     func testMissingColor() {
+        YCoreUI.isLoggingEnabled = false
+
         PrimaryColors.allCases.forEach {
             XCTAssertNil($0.loadColor())
             XCTAssertEqual($0.color, PrimaryColors.fallbackColor)
         }
+        
+        YCoreUI.isLoggingEnabled = true
+    }
+
+    func test_calculateName_deliversCorrectName() {
+        PrimaryColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), $0.rawValue)
+        }
+
+        ErrorColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), "Error/\($0.rawValue)")
+        }
+
+        WarningColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), $0.rawValue)
+        }
+    }
+
+    func test_colorable_deliversDefaultFallbackColor() {
+        XCTAssertEqual(DefaultColors.defaultCase.color, DefaultColors.fallbackColor)
     }
 }
 
@@ -69,5 +93,9 @@ private extension ColorableTests {
         case primary100
 
         static var fallbackColor: UIColor { .systemPurple }
+    }
+
+    enum DefaultColors: String, CaseIterable, Colorable {
+        case defaultCase
     }
 }

--- a/Tests/YCoreUITests/Protocols/ColorableTests.swift
+++ b/Tests/YCoreUITests/Protocols/ColorableTests.swift
@@ -41,10 +41,32 @@ final class ColorableTests: XCTestCase {
     }
 
     func testMissingColor() {
+        YCoreUI.isLoggingEnabled = false
+
         PrimaryColors.allCases.forEach {
             XCTAssertNil($0.loadColor())
             XCTAssertEqual($0.color, PrimaryColors.fallbackColor)
         }
+        
+        YCoreUI.isLoggingEnabled = true
+    }
+
+    func test_calculateName_deliversCorrectName() {
+        PrimaryColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), $0.rawValue)
+        }
+
+        ErrorColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), "Error/\($0.rawValue)")
+        }
+
+        WarningColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), $0.rawValue)
+        }
+    }
+
+    func test_colorable_deliversDefaultFallbackColor() {
+        XCTAssertEqual(DefaultColors.defaultCase.color, DefaultColors.fallbackColor)
     }
 }
 
@@ -69,5 +91,9 @@ private extension ColorableTests {
         case primary100
 
         static var fallbackColor: UIColor { .systemPurple }
+    }
+
+    enum DefaultColors: String, CaseIterable, Colorable {
+        case defaultCase
     }
 }

--- a/Tests/YCoreUITests/Protocols/ColorableTests.swift
+++ b/Tests/YCoreUITests/Protocols/ColorableTests.swift
@@ -31,14 +31,12 @@ final class ColorableTests: XCTestCase {
     func testLoadColorWithoutNamespace() {
         WarningColors.allCases.forEach {
             XCTAssertNotNil($0.loadColor())
-            XCTAssertNotEqual($0.color, WarningColors.fallbackColor)
         }
     }
 
     func testLoadColorWithNamespace() {
         ErrorColors.allCases.forEach {
             XCTAssertNotNil($0.loadColor())
-            XCTAssertNotEqual($0.color, ErrorColors.fallbackColor)
         }
     }
 


### PR DESCRIPTION
## Introduction ##

Our Colorable protocol helps users load (and unit test) colors from asset catalogs. It provides a fallback color to use in case the named color asset cannot be found. In that case though we should log a warning message.
Extract the code that builds name from namespace + rawValue into an internal calculateName() method and cover it in unit tests.
In ColorableTests try to minimize use of logger. Ideally log only one message before disabling the logging for remainder of failure cases
## Purpose ##

Add logger to colorable protocol and add unit test for above scenarios.
## Scope ##

Colorable protocol and Unit test for same protocol.
## 📈 Coverage ##

##### Code #####

100%
<img width="982" alt="Code coverage" src="https://user-images.githubusercontent.com/111066844/231063474-9348193b-c497-4f42-8de0-b68c135646ee.png">

##### Documentation #####

100%
<img width="565" alt="Jazzy" src="https://user-images.githubusercontent.com/111066844/231063530-13eab8bc-9f70-4345-8be4-a05891214112.png">
