### PR TITLE
[ISSUE] Add logger to colorable on fallBack

### DIFF
--- a/Sources/YCoreUI/Protocols/Colorable.swift
+++ b/Sources/YCoreUI/Protocols/Colorable.swift
@@ -53,17 +53,29 @@ extension Colorable {
     /// (prepended to `rawValue`) and `bundle`.
     /// - Returns: The named color or else `nil` if the named asset cannot be loaded
     public func loadColor() -> UIColor? {
+        UIColor(named: calculateName(), in: Self.bundle, compatibleWith: nil)
+    }
+
+    internal func calculateName() -> String {
         let name: String
         if let validNamespace = Self.namespace {
             name = "\(validNamespace)/\(rawValue)"
         } else {
             name = rawValue
         }
-        return UIColor(named: name, in: Self.bundle, compatibleWith: nil)
+        return name
     }
-    
+
     /// A color asset for this name value.
     ///
-    /// Default implementation calls `loadColor` and nil-coalesces to `fallbackColor`.
-    public var color: UIColor { loadColor() ?? Self.fallbackColor }
+    /// Returns `loadColor()` nil-coalesced to `fallbackColor`.
+    public var color: UIColor {
+        guard let color = loadColor() else {
+            if YCoreUI.isLoggingEnabled {
+                YCoreUI.colorLogger.warning("Color named \(calculateName()) failed to load from bundle.")
+            }
+            return Self.fallbackColor
+        }
+        return color
+    }
 }

--- a/Sources/YCoreUI/Protocols/Colorable.swift
+++ b/Sources/YCoreUI/Protocols/Colorable.swift
@@ -15,43 +15,35 @@ import UIKit
 ///  package, override `bundle` to return `.module`. If your assets are categorized within their asset catalog by
 ///  a namespace, then override `namespace` to return the proper string prefix.
 public protocol Colorable: RawRepresentable where RawValue == String {
-    /// The bundle containing the color assets for this enum (default is `.main`)
+    /// The bundle containing the color assets for this enum.
     static var bundle: Bundle { get }
 
-    /// Optional namespace for the color assets (default is `nil`)
+    /// Optional namespace for the color assets.
     static var namespace: String? { get }
     
-    /// Fallback color to use in case a color asset cannot be loaded (default is `.systemPink`)
+    /// Fallback color to use in case a color asset cannot be loaded.
     static var fallbackColor: UIColor { get }
 
     /// Loads the named color.
-    ///
-    /// Default implementation uses `UIColor(named:in:compatibleWith:)` passing in the associated `namespace`
-    /// (prepended to `rawValue`) and `bundle`.
     /// - Returns: The named color or else `nil` if the named asset cannot be loaded
     func loadColor() -> UIColor?
     
     /// A color asset for this name value.
-    ///
-    /// Default implementation calls `loadColor` and nil-coalesces to `fallbackColor`.
     var color: UIColor { get }
 }
 
 extension Colorable {
-    /// The bundle containing the color assets for this enum (default is `.main`)
+    /// Returns the `.main` bundle.
     public static var bundle: Bundle { .main }
 
-    /// Optional namespace for the color assets (default is `nil`)
+    /// Returns `nil` to indicate no namespace.
     public static var namespace: String? { nil }
     
-    /// Fallback color to use in case a color asset cannot be loaded (default is `.systemPink`)
+    /// Returns `.systemPink` color.
     public static var fallbackColor: UIColor { .systemPink }
     
-    /// Loads the named color.
-    ///
-    /// Default implementation uses `UIColor(named:in:compatibleWith:)` passing in the associated `namespace`
+    /// Returns `UIColor(named:in:compatibleWith:)` passing in the associated `namespace`
     /// (prepended to `rawValue`) and `bundle`.
-    /// - Returns: The named color or else `nil` if the named asset cannot be loaded
     public func loadColor() -> UIColor? {
         UIColor(named: calculateName(), in: Self.bundle, compatibleWith: nil)
     }
@@ -66,9 +58,9 @@ extension Colorable {
         return name
     }
 
-    /// A color asset for this name value.
-    ///
     /// Returns `loadColor()` nil-coalesced to `fallbackColor`.
+    ///
+    /// Unless logging is disabled, a warning message will be logged to the console if the color asset fails to load.
     public var color: UIColor {
         guard let color = loadColor() else {
             if YCoreUI.isLoggingEnabled {

--- a/Tests/YCoreUITests/Protocols/ColorableTests.swift
+++ b/Tests/YCoreUITests/Protocols/ColorableTests.swift
@@ -41,10 +41,42 @@ final class ColorableTests: XCTestCase {
     }
 
     func testMissingColor() {
+        YCoreUI.isLoggingEnabled = false
+
         PrimaryColors.allCases.forEach {
             XCTAssertNil($0.loadColor())
             XCTAssertEqual($0.color, PrimaryColors.fallbackColor)
         }
+
+        YCoreUI.isLoggingEnabled = true
+    }
+
+    func test_calculateName_deliversCorrectName() {
+        PrimaryColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), $0.rawValue)
+        }
+
+        ErrorColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), "Error/\($0.rawValue)")
+        }
+
+        WarningColors.allCases.forEach {
+            XCTAssertEqual($0.calculateName(), $0.rawValue)
+        }
+    }
+
+    func test_colorable_deliversCorrectColor() {
+        ErrorColors.allCases.forEach {
+            XCTAssertNotEqual($0.color, ErrorColors.fallbackColor)
+        }
+        
+        WarningColors.allCases.forEach {
+            XCTAssertNotEqual($0.color, WarningColors.fallbackColor)
+        }
+    }
+
+    func test_colorable_deliversDefaultFallbackColor() {
+        XCTAssertEqual(DefaultColors.defaultCase.color, DefaultColors.fallbackColor)
     }
 }
 
@@ -69,5 +101,9 @@ private extension ColorableTests {
         case primary100
 
         static var fallbackColor: UIColor { .systemPurple }
+    }
+
+    enum DefaultColors: String, CaseIterable, Colorable {
+        case defaultCase
     }
 }


### PR DESCRIPTION
## Introduction ##

Our Colorable protocol helps users load (and unit test) colors from asset catalogs. It provides a fallback color to use in case the named color asset cannot be found. In that case though we should log a warning message.
Extract the code that builds name from namespace + rawValue into an internal calculateName() method and cover it in unit tests.
In ColorableTests try to minimize use of logger. Ideally log only one message before disabling the logging for remainder of failure cases
## Purpose ##

Add logger to colorable protocol and add unit test for above scenarios.
Fix https://github.com/yml-org/YCoreUI/issues/55
## Scope ##

Colorable protocol and Unit test for same protocol.
## 📈 Coverage ##

##### Code #####

100%
<img width="982" alt="Code coverage" src="https://user-images.githubusercontent.com/111066844/231075793-47412b1b-2274-438e-917f-8fc1e7bcf03f.png">


##### Documentation #####

100%
<img width="565" alt="Jazzy" src="https://user-images.githubusercontent.com/111066844/231063530-13eab8bc-9f70-4345-8be4-a05891214112.png">
